### PR TITLE
Use http git URL for corporate firewalls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'thor-foodcritic'
 gem 'vagrant', '~> 1.0.6'
 
 group :integration do
-  gem 'test-kitchen', :git => "git://github.com/opscode/test-kitchen.git", :branch => '1.0'
-  gem 'kitchen-vagrant', :git => "git://github.com/opscode/kitchen-vagrant.git"
-  gem 'kitchen-ec2', :git => "git://github.com/opscode/kitchen-ec2.git"
+  gem 'test-kitchen', :git => "http://github.com/opscode/test-kitchen.git", :branch => '1.0'
+  gem 'kitchen-vagrant', :git => "http://github.com/opscode/kitchen-vagrant.git"
+  gem 'kitchen-ec2', :git => "http://github.com/opscode/kitchen-ec2.git"
 end


### PR DESCRIPTION
Corporate firewalls always block the git:// protocol. Changed it to HTTP and now bundle install works great.
