### PR TITLE
Set install_method and include nodejs::default

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,10 +22,12 @@ include_recipe "runit"
 
 case node['platform_family']
 when "debian"
-  include_recipe "nodejs::install_from_package"
+  node.set['nodejs']['install_method'] = "package"
 else
-  include_recipe "nodejs::install_from_source"
+  node.set['nodejs']['install_method'] = "source"
 end
+
+include_recipe "nodejs"
 
 user node['hubot']['user'] do
   comment "Hubot User"


### PR DESCRIPTION
Instead of explicitly calling `nodejs::install_from_package` or `nodejs::install_from_source`, set `node['nodejs']['install_method']` and include the default nodejs recipe, which will call the appropriate install recipe.

This lets me specify install_method as an override attribute in my wrapper/app cookbook to use `nodejs::install_from_binary`, which is about 1 million times faster :)
