### PR TITLE
Better handling of environment variables

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -98,15 +98,7 @@ execute "npm install" do
   notifies :restart, "service[hubot]", :delayed
 end
 
-template "#{node['hubot']['install_dir']}/hubot.conf" do
-  source 'hubot.conf.erb'
-  owner node['hubot']['user']
-  group node['hubot']['group']
-  mode 0600
-  variables node['hubot'].to_hash
-  notifies :restart, "service[hubot]", :delayed
-end
-
 runit_service "hubot" do
   options node['hubot'].to_hash
+  env node['hubot']['config']
 end

--- a/templates/default/hubot.conf.erb
+++ b/templates/default/hubot.conf.erb
@@ -1,3 +1,0 @@
-<%- @config.each_pair do |k,v| -%>
-<%= k.to_s.upcase %>='<%= v %>'
-<%- end -%>

--- a/templates/default/sv-hubot-run.erb
+++ b/templates/default/sv-hubot-run.erb
@@ -2,8 +2,7 @@
 
 exec 2>&1
 export PATH=<%= @options['install_dir'] %>/node_modules/.bin:$PATH
-CONFIG=$(cat <%= @options['install_dir'] %>/hubot.conf)
 cd <%= @options['install_dir'] %>
-exec chpst -u <%= @options['user'] %> -U <%= @options['user'] %> \
-  env HOME="<%= @options['install_dir'] %>" $CONFIG \
+exec chpst -u <%= @options['user'] %> -U <%= @options['user'] %> -e "<%= @options[:env_dir] %>" \
+  env HOME="<%= @options['install_dir'] %>" \
   bin/hubot --name '<%= @options['name'] %>' --adapter <%= @options['adapter'] %>


### PR DESCRIPTION
Use runit's built in mechanism for handling environment variables, which is set by using the env parameter in the runit_service definition.

It puts each environment variable in a directory (one file per variable) which is interpreted when the service starts. The default location is /etc/service/hubot/env/. This handles numeric values, although you need to quote them in your recipe, and values with spaces.
For Example:
node.set['hubot']['config'] = {
  "PORT" => "9000",
  "GTALK_PRESENCE" => "Echoing to campfire"
}

For more info on chpst -e see http://smarden.org/runit/chpst.8.html
