### PR TITLE
Cook hubot from different repository than official

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,8 @@ default['hubot']['user'] = "hubot"
 default['hubot']['group'] = "hubot"
 default['hubot']['private'] = true
 
+default['hubot']['repository'] = "https://github.com/github/hubot.git"
+
 default['hubot']['name'] = "hubot"
 default['hubot']['adapter'] = "campfire"
 default['hubot']['config'] = Hash.new

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,7 +48,8 @@ end
 # https://github.com/github/hubot/archive/v2.4.6.zip
 checkout_location = ::File.join(Chef::Config[:file_cache_path], "hubot")
 git checkout_location do
-  repository "https://github.com/github/hubot.git"
+  repository "#{node['hubot']['repository']}"
+  #repository "https://github.com/github/hubot.git"
   revision "v#{node['hubot']['version']}"
   action :checkout
   notifies :run, "execute[build and install hubot]", :immediately


### PR DESCRIPTION
The cookbook should allow the user to cook a machine with a hubot from a different repository than the official one. I added a new attribute, which defaults to the official repo, however it can be overwritten to any git repository with hubot.
