### PR TITLE
Update to new hubot version, avoid using --create

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,11 +17,11 @@
 # limitations under the License.
 #
 
-default['hubot']['version'] = '2.4.6'
-default['hubot']['scripts_version'] = '2.4.1'
-default['hubot']['install_dir'] = '/opt/hubot'
-default['hubot']['user'] = 'hubot'
-default['hubot']['group'] = 'hubot'
+default['hubot']['version'] = "2.11.0"
+default['hubot']['scripts_version'] = "2.5.16"
+default['hubot']['install_dir'] = "/opt/hubot"
+default['hubot']['user'] = "hubot"
+default['hubot']['group'] = "hubot"
 default['hubot']['private'] = true
 
 default['hubot']['name'] = 'hubot'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,9 +49,8 @@ end
 execute 'build and install hubot' do
   command <<-EOH
 npm install
-bin/hubot -c #{node['hubot']['install_dir']}
 chown #{node['hubot']['user']}:#{node['hubot']['group']} -R #{node['hubot']['install_dir']}
-chmod 0755 #{node['hubot']['install_dir']}/bin/hubot
+chmod 0755 #{node['hubot']['install_dir']}/node_modules/.bin/hubot
   EOH
   cwd checkout_location
   environment(

--- a/templates/default/sv-hubot-run.erb
+++ b/templates/default/sv-hubot-run.erb
@@ -5,4 +5,4 @@ export PATH=<%= @options['install_dir'] %>/node_modules/.bin:$PATH
 cd <%= @options['install_dir'] %>
 exec chpst -u <%= @options['user'] %> -U <%= @options['user'] %> -e "<%= @options[:env_dir] %>" \
   env HOME="<%= @options['install_dir'] %>" \
-  bin/hubot --name '<%= @options['name'] %>' --adapter <%= @options['adapter'] %>
+  hubot --name '<%= @options['name'] %>' --adapter <%= @options['adapter'] %>


### PR DESCRIPTION
Hubot has moved to using Yeoman to generate new installs, and no longer uses the --create parameter, which is used in this cookbook. I've removed the use of --create, and modified the service definition to call hubot directory from the checked out sources.